### PR TITLE
Sidekiq Enhancements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ gem "kaminari"
 # background tasks
 gem "sidekiq"
 gem "sidekiq-scheduler"
+gem "sidekiq-statistic"
 
 # dependabot alerts
 gem "rack", ">= 2.2.6.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,6 +344,9 @@ GEM
       rufus-scheduler (~> 3.2)
       sidekiq (>= 4, < 7)
       tilt (>= 1.4.0)
+    sidekiq-statistic (1.4.0)
+      sidekiq (>= 5.0)
+      tilt (~> 2.0)
     solargraph (0.48.0)
       backport (~> 1.2)
       benchmark
@@ -446,6 +449,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq
   sidekiq-scheduler
+  sidekiq-statistic
   solargraph
   solargraph-rails
   sprockets-rails

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,8 @@
+# The Statistic configuration is an initializer that GEM
+# uses to configure itself. The option max_timelist_length
+# is used to avoid memory leak, in practice, whenever the
+# cache size reaches that number, the GEM is going to
+# remove 25% of the key values, avoiding inflating memory.
+Sidekiq::Statistic.configure do |config|
+  config.max_timelist_length = 100_000
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,5 +7,6 @@ production:
 :max_retries: 1
 
 :queues:
-  - default
-  - mailers
+  - ["critical", 4]
+  - ["default", 2]
+  - ["mailers", 1]


### PR DESCRIPTION
@tarunvelli I've made some changes to the sidekiq setup in the app. Practices that will help the people who use this starter kit.

1. Sidekiq best practice: see [Tips on Sidekiq Queues](https://philsturgeon.com/tips-on-sidekiq-queues/) for the reasoning behind queue weighting.
2. Added statistics tracking for jobs on the sidekiq web view. The gem tracks how long jobs take to process.
